### PR TITLE
Templates fix

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Ziggeo ===
 Contributors: oliverfriedmann, baned
-Donate link: http://ziggeo.com/
-Tags: comments, posts, video comments, crowdsourced video, crowdsourced video plugin, page, recorder, user generated content, user generated content plugin, user generated video, video comments, video posts, video recorder, video recording, video reviews, video submission, video submission plugin, video testimonial plugin, video testimonials, video upload, video widget, webcam, webcam recorder
+Donate link: https://ziggeo.com/
+Tags: video, comments, posts, video comments, crowdsourced video, crowdsourced video plugin, page, recorder, user generated content, user generated content plugin, user generated video, video comments, video posts, video recorder, video recording, video reviews, video submission, video submission plugin, video testimonial plugin, video testimonials, video upload, video widget, webcam, webcam recorder
 Requires at least: 3.0.1
 Tested up to: 4.5.2
-Stable tag: 1.11
+Stable tag: 1.12
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -290,11 +290,16 @@ Clicking on it again will stop it from being 'beta'.
 
 == Upgrade notice ==
 
-= 1.11 =
-* Templates are now available in Ziggeo plugin
+= 1.12 =
+* Fixes related to templates structure
 
 
 == Changelog ==
+
+= 1.12 =
+* Fixed issue with double quotes stopping TinyMCE button in toolbar to not work properly
+* Fixed issue with double quotes breaking template editing option
+* Fixed template parsing in comments to allow template to be used and custom parameters
 
 = 1.11 =
 * Templates tab added to the plugin to expand its possibilities/features

--- a/src/settings.php
+++ b/src/settings.php
@@ -31,8 +31,8 @@ function ziggeo_admin_init() {
 
                 //Templates section
                 add_settings_field('ziggeo_templates_id', 'Template ID', 'ziggeo_templates_id_string', 'ziggeo_video', 'ziggeo_video_templates');
-                add_settings_field('ziggeo_templates_editor', 'Template Editor', 'ziggeo_templates_editor_string', 'ziggeo_video', 'ziggeo_video_templates');
                 add_settings_field('ziggeo_templates_manager', 'Manage your templates', 'ziggeo_templates_manager_string', 'ziggeo_video', 'ziggeo_video_templates');
+                add_settings_field('ziggeo_templates_editor', 'Template Editor', 'ziggeo_templates_editor_string', 'ziggeo_video', 'ziggeo_video_templates');
 
                 //Contact us section
                 add_settings_field('ziggeo_contact_ziggeo', 'Contact Us on our platform', 'ziggeo_contact_ziggeo_string', 'ziggeo_video', 'ziggeo_video_contact');
@@ -106,6 +106,32 @@ function ziggeo_video_templates_text() {
                 //On load, we do not need to load any data, just have the box empty. When we get back the response, that is when we need to capture the data..
                 ?>
                 <input id="ziggeo_templates_id" name="ziggeo_video[templates_id]" size="50" type="text" placeholder="Give the template any name you wish here" value="" />
+                <?php
+        }
+
+        //This function build the interface that will help us show and manage the templates.
+        //It will show a list of templates and over each, at the top right corner there should be options to edit and remove the same.
+        function ziggeo_templates_manager_string() {
+                ?>
+                <div>
+                        <ul class="ziggeo-manage_list">
+                                <?php
+                                        $list = ziggeo_templates_index();
+                                        if($list) {
+                                                foreach($list as $template => $value)
+                                                {
+                                                        ?><li><?php echo $template; ?> <span class="delete">x</span><span class="edit" data-template="<?php echo $value; ?>">edit</span></li><?php
+                                                }                                               
+                                        }
+                                        else {
+                                                ?><li>No templates yet, please create one</li><?php
+                                        }
+                                ?>
+                                <?php //Edit should do //document.location += "#ziggeo_editing" while edit should do confirm() ?>
+                        </ul>
+                        <?php //We use this to help us see what action we need to make.. if edit, or delete, we store the old ID into its value, while it is empty if we create new ?>
+                        <input type="hidden" id="ziggeo_templates_manager" name="ziggeo_video[templates_manager]" value="">
+                </div>
                 <?php
         }
 
@@ -258,32 +284,6 @@ function ziggeo_video_templates_text() {
                         </dl>
                 </div>
                 <br style="clear: both;">
-                <?php
-        }
-
-        //This function build the interface that will help us show and manage the templates.
-        //It will show a list of templates and over each, at the top right corner there should be options to edit and remove the same.
-        function ziggeo_templates_manager_string() {
-                ?>
-                <div>
-                        <ul class="ziggeo-manage_list">
-                                <?php
-                                        $list = ziggeo_templates_index();
-                                        if($list) {
-                                                foreach($list as $template => $value)
-                                                {
-                                                        ?><li><?php echo $template; ?> <span class="delete">x</span><span class="edit" data-template="<?php echo $value; ?>">edit</span></li><?php
-                                                }                                               
-                                        }
-                                        else {
-                                                ?><li>No templates yet, please create one</li><?php
-                                        }
-                                ?>
-                                <?php //Edit should do //document.location += "#ziggeo_editing" while edit should do confirm() ?>
-                        </ul>
-                        <?php //We use this to help us see what action we need to make.. if edit, or delete, we store the old ID into its value, while it is empty if we create new ?>
-                        <input type="hidden" id="ziggeo_templates_manager" name="ziggeo_video[templates_manager]" value="">
-                </div>
                 <?php
         }
 

--- a/src/templates.php
+++ b/src/templates.php
@@ -127,7 +127,15 @@ function ziggeo_templates_index() {
 	//path to custom templates file
 	$file = ZIGGEO_DATA_ROOT_PATH . 'custom_templates.php';
 
-	return ziggeo_file_read($file);
+	$ret = ziggeo_file_read($file);
+
+	if($ret) {
+		//If there are double quotes, it would cause issues with TinyMCE, however with templates editing as well.
+		//Since this is called for templates only, we know that we are OK with changing all double quotes into single quotes..
+		$ret = str_replace('"', "'", $ret);		
+	}
+
+	return $ret;
 }
 
 //Checks if the template with specified ID exists or not

--- a/src/ziggeo_tinymce_plugin.php
+++ b/src/ziggeo_tinymce_plugin.php
@@ -8,6 +8,13 @@ include_once('./file_parser.php');
 
 $list = ziggeo_file_read( '../../ziggeo-userData/custom_templates.php' );
 
+
+if($list) {
+	//If there are double quotes, it would cause issues with TinyMCE, however with templates editing as well.
+	//Since this is called for templates only, we know that we are OK with changing all double quotes into single quotes..
+	$list = str_replace('"', "'", $list);		
+}
+
 $start = "(function() {
     tinymce.create('tinymce.plugins.ziggeo', {
         /**
@@ -39,7 +46,7 @@ if($list) {
         //player and re-recorder require token.. so it would be good to detect which base the template has and then add any required attributes to the same..
         foreach($list as $id => $template) {
 
-                $tokenRequired = 'false';
+                $tokenRequired = 'no';
                 //We will check each since we want people to be able to add 2 or more templates ;)
 
                 //Are we dealing with player?
@@ -47,7 +54,7 @@ if($list) {
                         if( stripos($template, 'video') === false ) { //nope, lets add it
                                 $template = str_replace( '[ziggeoplayer', '[ziggeoplayer video=\'<span id=\"ziggeo_token_range_s\"></span>YOUR_VIDEO_TOKEN<span id=\"ziggeo_token_range_e\"></span>\'', $template);
                         }
-                        $tokenRequired = 'true';
+                        $tokenRequired = 'yes';
                 }
 
                 //are we dealing with the rerecorder?
@@ -56,7 +63,7 @@ if($list) {
                         if( stripos($template, 'video') === false ) { //nope, lets add it
                                 $template = str_replace('[ziggeorerecorder', '[ziggeorerecorder video=\'<span id=\"ziggeo_token_range_s\"></span>YOUR_VIDEO_TOKEN<span id=\"ziggeo_token_range_e\"></span>\'', $template);
                         }
-                        $tokenRequired = 'true';
+                        $tokenRequired = 'yes';
                 }
 
                 if($middle !== '')      { $middle .= ', '; }
@@ -70,7 +77,7 @@ if($list) {
                                                                 editor.insertContent(this.value());
                                                         }
                                                         else {
-                                                                if(this.settings.requiresToken) {
+                                                                if(this.settings.requiresToken === 'yes') {
                                                                         editor.insertContent('[ziggeo ' + this.text() + ' video=\'<span id=\"ziggeo_token_range_s\"></span>YOUR_VIDEO_TOKEN<span id=\"ziggeo_token_range_e\"></span>\' ]');                                                                     
                                                                 }
                                                                 else {

--- a/templates/comments_template.php
+++ b/templates/comments_template.php
@@ -37,6 +37,9 @@ if($template_recorder) {
 	//Just confirm it one more time which one we should use, in case template was removed and settings not updated.
 	//maybe change this to raise a notification if it happens to call deleted template.
 	$default_recorder = ( $tempParams ) ? $tempParams : $default_recorder;
+
+	//Make sure that template is parsed and prefix added if needed.
+	$default_recorder = ziggeo_parameter_prep($default_recorder);
 }
 
 //Player defaults to be used in comments.
@@ -53,6 +56,9 @@ if($template_player) {
 	//Just confirm it one more time which one we should use, in case template was removed and settings not updated.
 	//maybe change this to raise a notification if it happens to call deleted template.
 	$default_player = ( $tempParams ) ? $tempParams : $default_player;
+
+	//Make sure that template is parsed and prefix added if needed.
+	$default_player = ziggeo_parameter_prep($default_player);
 }
 
 

--- a/ziggeo.php
+++ b/ziggeo.php
@@ -1,12 +1,11 @@
 <?php 
     /*
     Plugin Name: Ziggeo Video Posts and Comments
-    Plugin URI: http://ziggeo.com
+    Plugin URI: https://ziggeo.com
     Description: Plugin for adding video posts and video comments
     Author: Ziggeo
-    Tags: comments, posts, video comments, crowdsourced video, crowdsourced video plugin, page, recorder, user generated content, user generated content plugin, user generated video, video comments, video posts, video recorder, video recording, video reviews, video submission, video submission plugin, video testimonial plugin, video testimonials, video upload, video widget, webcam, webcam recorder, video player, video gallery, video uploads, video submissions
-    Version: 1.11
-    Author URI: http://ziggeo.com
+    Version: 1.12
+    Author URI: https://ziggeo.com
     */
 
 //Checking if WP is running or if this is a direct call..


### PR DESCRIPTION
The templates worked in comments, however the custom parameters did not work when in comments so this was added.

Fix was made to resolve the parameters properly - by adding "ziggeo-" prefix if missing.

Fixed issue with TinyMCE caused by double quotes as well an issue caused by the same when trying to edit the templates.
- Readme is updated as well and tags section removed from main php file since it is read from readme file by WordPress.
