### PR TITLE
Development

### DIFF
--- a/css/admin-styles.css
+++ b/css/admin-styles.css
@@ -116,6 +116,14 @@
     background-image: linear-gradient(lightblue, transparent);
     border: 1px solid lightblue;
 }
+.ziggeo_info {
+    background-image: linear-gradient(gold, orange, gold);
+    border-radius: 4px 4px 4px 0;
+    font-size: 0.9em;
+    font-style: italic;
+    padding: 0.2em 0.6em;
+    margin-bottom: 2em;
+}
 
 /* General tab */
 #ziggeo-tab_general .form-table tr:hover .ziggeo-subframe {

--- a/js/admin.js
+++ b/js/admin.js
@@ -53,12 +53,17 @@ function ziggeo_templates_change(sel) {
     //Lets grab the parameter holders
     var wallParams = document.getElementById('ziggeo-wall-parameters');
     var embeddingParams = document.getElementById('ziggeo-embedding-parameters');
+
+    //videowall info
+    var wallInfo = document.getElementById('ziggeo_videowall_info');
+    wallInfo.style.display = 'none';
  
     //If it is video wall we want to show its parameters
     if(selected === '[ziggeovideowall'){
         editor.value = selected + ' ';
         wallParams.style.display = 'block';
         embeddingParams.style.display = 'none';
+        wallInfo.style.display = 'inline-block';
     }
     //otherwise lets show Ziggeo embedding parameters
     else {
@@ -301,10 +306,15 @@ function ziggeo_templates_manage(event) {
         var paramsWall = document.getElementById('ziggeo-wall-parameters');
         var paramsZiggeo = document.getElementById('ziggeo-embedding-parameters');
 
+        //videowall info
+        var wallInfo = document.getElementById('ziggeo_videowall_info');
+        wallInfo.style.display = 'none';
+
         if(templateBase === '[ziggeovideowall') {
             //show parameters for video wall
             paramsWall.style.display = 'block';
             paramsZiggeo.style.display = 'none';
+            wallInfo.style.display = 'inline-block';
         }
         else {
             //show ziggeo parameters

--- a/js/ziggeo_plugin.js
+++ b/js/ziggeo_plugin.js
@@ -23,7 +23,9 @@ if(typeof ziggeoShowVideoWall !== 'function') {
         html += ZiggeoWall[id].title;
 
         //To show the page we must first index videos..
-        ZiggeoApi.Videos.index(ZiggeoWall[id].tags, {
+
+        //We are making it get 100 videos data per call
+        ZiggeoApi.Videos.index( 'limit=100&tags='+ZiggeoWall[id].tags, {
             success: function (args, data) {
                 if(data.length > 0) {
                     //we got some videos back

--- a/js/ziggeo_plugin.js
+++ b/js/ziggeo_plugin.js
@@ -50,30 +50,33 @@ if(typeof ziggeoShowVideoWall !== 'function') {
                                     '></ziggeo>';
 
                         //show all videos
-                        if(ZiggeoWall[id].indexing.status === 'all') {
+                        if(ZiggeoWall[id].indexing.status.indexOf('all') > -1 ) {
                             tmp += tmp_embedding;
                             usedVideos++;
                             currentVideosPageCount++;
+                            data[i] = null;//so that it is not used by other ifs..
                         }
                         //show only rejected videos
-                        else if(ZiggeoWall[id].indexing.status === 'rejected') {
-                           if(data[i].approved === false) {
+                        if(ZiggeoWall[id].indexing.status.indexOf('rejected') > -1 ) {
+                           if(data[i] !== null && data[i].approved === false) {
                                 tmp += tmp_embedding;
                                 usedVideos++;
                                 currentVideosPageCount++;
+                                data[i] = null;//so that it is not used by other ifs..
                            }
                         }
                         //show only pending videos
-                        else if(ZiggeoWall[id].indexing.status === 'pending') {
-                           if(data[i].approved === null || data[i].approved === '' ) {
+                        if(ZiggeoWall[id].indexing.status.indexOf('pending') > -1 ) {
+                           if(data[i] !== null && (data[i].approved === null || data[i].approved === '') ) {
                                 tmp += tmp_embedding;
                                 usedVideos++;
                                 currentVideosPageCount++;
+                                data[i] = null;//so that it is not used by other ifs..
                            }
                         }
                         //show approved videos 
-                        else {
-                            if(data[i].approved === true) {
+                        if(ZiggeoWall[id].indexing.status === '' || ZiggeoWall[id].indexing.status.indexOf('approved') > -1 ) {
+                            if(data[i] !== null && data[i].approved === true) {
                                 tmp += tmp_embedding;
                                 usedVideos++;
                                 currentVideosPageCount++;

--- a/readme.txt
+++ b/readme.txt
@@ -345,11 +345,16 @@ To show videos you need to have videos on that specific page. This is done to al
 
 == Upgrade notice ==
 
-= 1.13 =
-* Introducing VideoWall template
+= 1.14 =
+* Added additional options to VideoWall templates
+* Made tests on latest WordPress version
 
 
 == Changelog ==
+
+= 1.14 =
+* Added option to show videos from different posts in a video wall
+* added option to show multiple types of videos (approved,rejected,pending) instead of single status.
 
 = 1.13 =
 * Fixed a small bug where additional spaces after template name would not allow you to delete/edit it easily

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: oliverfriedmann, baned
 Donate link: https://ziggeo.com/
 Tags: video, comments, posts, video comments, crowdsourced video, crowdsourced video plugin, page, recorder, user generated content, user generated content plugin, user generated video, video comments, video posts, video recorder, video recording, video reviews, video submission, video submission plugin, video testimonial plugin, video testimonials, video upload, video widget, webcam, webcam recorder
 Requires at least: 3.0.1
-Tested up to: 4.5.2
-Stable tag: 1.13
+Tested up to: 4.5.3
+Stable tag: 1.14
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -140,6 +140,13 @@ As you do, your post will show the wall as per template setup, which means that 
 1. Show a message if no videos are present - or show another template instead.
 
 * Yes, you read that correctly. If you show your video wall, and you want to show a template within it - that is possible allowing you to quickly add more videos.
+
+By default the video wall will show you the videos made on the specific post (the one it is on), however if you wish to show videos from other posts or that are not associated yet with your WordPress, you can do that as well through videos_to_show parameter.
+
+You can read more about Video Wall templates on the following useful links:
+[Help Center](https://support.ziggeo.com/hc/en-us)
+[Introduction to VideoWall on our blog](http://blog.ziggeo.com/2016/06/13/videowall-the-best-way-to-easily-show-a-video-gallery-on-your-wordpress-based-website/)
+[Introduction to showing videos from other post on our forum](https://support.ziggeo.com/hc/en-us/community/posts/212117427-VideoWall-parameters-introducing-new-changes)
 
 = Templates =
 

--- a/src/player.php
+++ b/src/player.php
@@ -403,6 +403,15 @@ function ziggeo_content_replace_templates($matches)
                     //Lets also add the code into the header, so it is not in the page content area..
                     add_action('wp_footer', 'ziggeo_wall_extra_css');
                 }
+
+                //We now allow customers to set custom tags to search videos by..This will provide them with more freedom.
+                if(!isset($wall['videos_to_show'])) {
+                    $wall_tags = 'wordpress,comment,post_' . $wall['postID']; //default that shows the videos made in the comments of the specific post
+                }
+                else {
+                    $wall_tags = $wall['videos_to_show'];
+                }
+
                 ?>
 
                 <script type="text/javascript">
@@ -432,7 +441,7 @@ function ziggeo_content_replace_templates($matches)
                             hideWall: <?php echo ($wall['hide_wall']) ? 'true' : 'false'; ?>
                         },
                         title: '<?php echo $wall['title']; ?>',
-                        tags: 'tags=wordpress,comment,post_<?php echo $wall['postID']; ?>' //do we want to show vidoes made in comments only or show all of them (made on this post)? - set to display comments only.
+                        tags: '<?php echo $wall_tags; ?>' //the tags to look the video by based on template setup
                     };
                 </script>
                 <?php

--- a/src/settings.php
+++ b/src/settings.php
@@ -169,6 +169,7 @@ function ziggeo_video_templates_text() {
 
         ?>
         <br><br>
+        <span id="ziggeo_videowall_info" class="ziggeo_info" style="display:none;">Video Wall template (by default) shows videos made on the post the videwall template is on. If you wish to change it to show other videos, just add <b onclick="ziggeo_parameters_quick_add({ currentTarget:this});" data-equal="=''">videos_to_show</b> and modify it to your needs</span>
 
         <?php //The actual template body that we will save ?>
         <textarea id="ziggeo_templates_editor" name="ziggeo_video[templates_editor]" rows="11" cols="50">[ziggeo </textarea>
@@ -469,7 +470,7 @@ function ziggeo_video_general_text() {
                     else{
                         ?><option value="<?php echo $template; ?>"><?php echo $template; ?></option><?php
                     }
-                }                               
+                }
             }
         ?>
         </select>
@@ -496,7 +497,7 @@ function ziggeo_video_general_text() {
                     else {
                         ?><option value="<?php echo $template; ?>"><?php echo $template; ?></option><?php                                               
                     }
-                }                               
+                }
             }
         ?>
         </select>

--- a/src/settings.php
+++ b/src/settings.php
@@ -199,6 +199,8 @@ function ziggeo_video_templates_text() {
                         <dd>Boolean value (enabled by default) - causing pages to be shown at the bottom</dd>
                     <dt class="wall" data-equal="=">videos_per_page</dt>
                         <dd>Integer value determining how many videos should be shown per page (defaults: 1 with slide_wall and 2 with show_pages)</dd>
+                    <dt class="wall" data-equal="=''">videos_to_show</dt>
+                        <dd>Array to setup which videos should be shown. Default video wall shows videos made on post it is on. This accepts comma separated values of post IDs (format: 'post_ID') or any other tags. Adding just '' (two single quotes) will show all videos in your account (videos_to_show='') <a href="https://support.ziggeo.com/hc/en-us/community/posts/212117427-VideoWall-parameters-introducing-new-changes">Check out more here..</a></dd>
                     <dt class="wall" data-equal="=''">on_no_videos</dt>
                         <dd>Array value representing what should happen if there are no videos. It can be 'showmessage', 'showtemplate', 'hidewall'</dd>
                     <dt class="wall" data-equal="=''">message</dt>

--- a/src/ziggeo_tinymce_plugin.php
+++ b/src/ziggeo_tinymce_plugin.php
@@ -26,22 +26,23 @@ $start = "(function() {
          * @param {string} url Absolute URL to where the plugin is located.
          */
         init : function(editor, url) {
-                        editor.addButton('ziggeo_templates', {
-                                title: 'Ziggeo Video Aid',
-                                cmd: 'ziggeoAddTemplate',
-                                image: url + '/../images/icon.png',
-                                type: 'menubutton',
-                                menu: [ //This is first level menu
-                                        {
-                                                text: 'Templates',
-                                                value: '[ziggeo]',
-                                                onclick: function() { //We will remove the onlick from here, this is just for test
-                                                        editor.insertContent(this.value());
-                                                },
-                                                menu: [ //This is second level menu
-                                                                ";
+            editor.addButton('ziggeo_templates', {
+                title: 'Ziggeo Video Aid',
+                cmd: 'ziggeoAddTemplate',
+                image: url + '/../images/icon.png',
+                type: 'menubutton',
+                menu: [ //This is first level menu
+                    {
+                        text: 'Templates',
+                        value: '[ziggeo]',
+                        onclick: function() { //We will remove the onlick from here, this is just for test
+                            editor.insertContent(this.value());
+                        },
+                        menu: [ //This is second level menu
+                                    ";
 
 $middle = '';
+$base = '[ziggeo ';
 if($list) {
         //player and re-recorder require token.. so it would be good to detect which base the template has and then add any required attributes to the same..
         foreach($list as $id => $template) {
@@ -51,56 +52,61 @@ if($list) {
 
                 //Are we dealing with player?
                 if( stripos( $template, '[ziggeoplayer' ) > -1 ) {
-                        if( stripos($template, 'video') === false ) { //nope, lets add it
-                                $template = str_replace( '[ziggeoplayer', '[ziggeoplayer video=\'<span id=\"ziggeo_token_range_s\"></span>YOUR_VIDEO_TOKEN<span id=\"ziggeo_token_range_e\"></span>\'', $template);
-                        }
-                        $tokenRequired = 'yes';
+                    if( stripos($template, 'video') === false ) { //nope, lets add it
+                        $template = str_replace( '[ziggeoplayer', '[ziggeoplayer video=\'<span id=\"ziggeo_token_range_s\"></span>YOUR_VIDEO_TOKEN<span id=\"ziggeo_token_range_e\"></span>\'', $template);
+                    }
+                    $tokenRequired = 'yes';
                 }
 
                 //are we dealing with the rerecorder?
                 if( stripos( $template, '[ziggeorerecorder') > -1 ) {
-                        //Is token already set?
-                        if( stripos($template, 'video') === false ) { //nope, lets add it
-                                $template = str_replace('[ziggeorerecorder', '[ziggeorerecorder video=\'<span id=\"ziggeo_token_range_s\"></span>YOUR_VIDEO_TOKEN<span id=\"ziggeo_token_range_e\"></span>\'', $template);
-                        }
-                        $tokenRequired = 'yes';
+                    //Is token already set?
+                    if( stripos($template, 'video') === false ) { //nope, lets add it
+                        $template = str_replace('[ziggeorerecorder', '[ziggeorerecorder video=\'<span id=\"ziggeo_token_range_s\"></span>YOUR_VIDEO_TOKEN<span id=\"ziggeo_token_range_e\"></span>\'', $template);
+                    }
+                    $tokenRequired = 'yes';
+                }
+
+                //If it is video wall, we should add it as ziggeowall, rather than ziggeo (because when template is removed the wall becomes recorder..)
+                if( stripos($template, '[ziggeovideowall') > -1 ) {
+                    $base = '[ziggeovideowall ';
                 }
 
                 if($middle !== '')      { $middle .= ', '; }
                 $middle .= "{
-                                                text: '" . $id . "',
-                                                value: \"" . $template . "\",
-                                                requiresToken: '" . $tokenRequired . "',
-                                                onclick: function(e) { 
-                                                        e.stopPropagation();
-                                                        if(e.shiftKey === true) {
-                                                                editor.insertContent(this.value());
-                                                        }
-                                                        else {
-                                                                if(this.settings.requiresToken === 'yes') {
-                                                                        editor.insertContent('[ziggeo ' + this.text() + ' video=\'<span id=\"ziggeo_token_range_s\"></span>YOUR_VIDEO_TOKEN<span id=\"ziggeo_token_range_e\"></span>\' ]');                                                                     
-                                                                }
-                                                                else {
-                                                                        editor.insertContent('[ziggeo ' + this.text() + ' ]');
-                                                                }
-                                                        }
-                                                        ziggeo_tinymce_set_position();
-                                                }
-                                        }";
+                                text: '" . $id . "',
+                                value: \"" . $template . "\",
+                                requiresToken: '" . $tokenRequired . "',
+                                onclick: function(e) { 
+                                    e.stopPropagation();
+                                    if(e.shiftKey === true) {
+                                            editor.insertContent(this.value());
+                                    }
+                                    else {
+                                        if(this.settings.requiresToken === 'yes') {
+                                            editor.insertContent('" . $base . "' + this.text() + ' video=\'<span id=\"ziggeo_token_range_s\"></span>YOUR_VIDEO_TOKEN<span id=\"ziggeo_token_range_e\"></span>\' ]');                                                                     
+                                        }
+                                        else {
+                                            editor.insertContent('" . $base . "' + this.text() + ' ]');
+                                        }
+                                    }
+                                    ziggeo_tinymce_set_position();
+                                }
+                            }";
         }
 }
 else {
         $middle = "{
-                                text: 'No templates found',
-                                value: ''
-                                }";
+                        text: 'No templates found',
+                        value: ''
+                    }";
 }
 
-$end =                                                  "
-                                                ]
-                                        }
-                                ]
-                        });
+$end =                       "
+                        ]
+                    }
+                ]
+            });
         },
  
         /**

--- a/ziggeo.php
+++ b/ziggeo.php
@@ -4,7 +4,7 @@
     Plugin URI: https://ziggeo.com
     Description: Plugin for adding video posts and video comments
     Author: Ziggeo
-    Version: 1.13
+    Version: 1.14
     Author URI: https://ziggeo.com
     */
 
@@ -22,14 +22,13 @@ define('ZIGGEO_DATA_ROOT_PATH', ZIGGEO_ROOT_PATH . '../ziggeo-userData/');
 define('ZIGGEO_DATA_ROOT_URL', plugins_url() . '/ziggeo-userData/');
 
 //plugin version - this way other plugins can get it as well and we will be updating this file for each version change as is
-define('ZIGGEO_VERSION', '1.13');
+define('ZIGGEO_VERSION', '1.14');
 
 //Best to state default code in one location, then just call for it when needed.
 //recorder
 define('ZIGGEO_DEFAULTS_RECORDER', 'ziggeo-width=360 ziggeo-height=240 ziggeo-limit=120');
 //player
 define('ZIGGEO_DEFAULTS_PLAYER', 'ziggeo-width=360 ziggeo-height=240');
-
 
 include_once(ZIGGEO_ROOT_PATH . "src/player.php");
 include_once(ZIGGEO_ROOT_PATH . "src/assets.php");


### PR DESCRIPTION
Added option to show videos from different posts, from wordpress, all, or any specific tag.

Also the option that allows you to select if you want approved, rejected, pending or all videos to be shown can now be set to multiple comma separated values.

There is also a notice shown when using video walls to say what it is all about.

Readme file is updated to reflect the changes.
